### PR TITLE
fix: update Dependabot workflow for setup-node v5 compatibility

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,15 +21,16 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
           version: '8.15.0'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'pnpm'
 
       - name: Update lockfile
         run: |


### PR DESCRIPTION
## Summary

Fixes the Dependabot workflow to be compatible with `actions/setup-node@v5` which is being updated by Dependabot itself.

## Problem

Dependabot PRs (#69, #72) are failing because:
1. The workflow uses `actions/setup-node@v4` but Dependabot is updating to v5
2. setup-node v5 has automatic package manager detection that runs before pnpm is installed
3. This causes "Unable to locate executable file: pnpm" error

## Solution

- Move `pnpm/action-setup` before `actions/setup-node` to ensure pnpm is available
- Update to `actions/setup-node@v5` to match what Dependabot is proposing
- Add `cache: 'pnpm'` for improved performance

## Testing

This will allow Dependabot PRs to:
- Successfully update the pnpm lockfile
- Auto-merge minor/patch updates
- Properly label major updates for manual review

Fixes issues seen in:
- #69 (actions/setup-node update)
- #72 (actions/checkout update)