### PR TITLE
Test Claude Review Comments Without track_progress

### DIFF
--- a/claude-validation.ts
+++ b/claude-validation.ts
@@ -1,8 +1,8 @@
 /**
- * CLAUDE CODE WORKING VALIDATION - FINAL TEST
+ * CLAUDE CODE VALIDATION - REVIEW COMMENTS FIX
  *
- * Enhanced workflow with use_sticky_comment + track_progress now on main!
- * Testing autonomous PR comment generation.
+ * Removed track_progress to enable actual PR review comments
+ * Should post line-specific violation findings
  */
 
 // HIGH CONFIDENCE: Direct ClickHouse import


### PR DESCRIPTION
Testing PR Review Comments Fix

Change Made: Removed track_progress from workflow to fix PR comment posting

Previous Issue: Claude was showing a todo list instead of posting actual violation findings

Expected Behavior: 
- Claude should post line-specific PR review comments
- Should detect 3 HIGH confidence violations in claude-validation.ts:
  - Line 9: Direct ClickHouse import
  - Line 13: Direct client instantiation
  - Line 16: Raw SQL string

Workflow Configuration:
- use_sticky_comment: true (kept for consolidated comments)
- track_progress: removed (was causing todo list display)

Lets see if Claude now posts actual review comments on the code violations!