### PR TITLE
fix: Enable Claude inline PR comments based on research

### DIFF
--- a/.github/workflows/claude-code-integration.yml
+++ b/.github/workflows/claude-code-integration.yml
@@ -159,11 +159,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          use_sticky_comment: true
+          claude_args: |
+            --max-turns 5
+            --model claude-3-haiku-20240307
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
           prompt: |
-            Review this pull request for architectural violations and post review comments on any violations found.
+            Review this pull request for architectural violations and post inline comments on any violations found.
 
-            **CRITICAL: Use GitHub's PR review comment feature to comment directly on the problematic lines of code.**
+            **CRITICAL: Use the mcp__github_inline_comment__create_inline_comment tool to comment directly on problematic lines.**
 
             **Priority Violations to Detect:**
             1. Direct @clickhouse/client imports outside storage package (HIGH confidence)
@@ -193,7 +196,6 @@ jobs:
             yield* storage.queryTraces(params)
             ```
             ```
-          claude_args: "--max-turns 5"
 
       - name: Slack Architectural Review Notification
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

Based on extensive research of working examples, this PR enables inline PR comments from Claude Code.

## Key Changes

- **Add --allowedTools parameter** with mcp__github_inline_comment__create_inline_comment tool
- **Remove use_sticky_comment** which was blocking inline comments  
- **Use multiline claude_args** for better readability
- **Update prompt** to explicitly reference the inline comment tool
- **Keep Haiku model** for cost efficiency

## Research Findings

From analyzing anthropics/claude-code-action repository:
- Their own workflow uses --allowedTools to enable inline comments
- Issue #60 shows users need to explicitly enable the tool
- Issue #567 confirms v1 has PR comment issues that many users face
- Several users report @beta works better than @v1

## Testing

This PR includes claude-validation.ts with clear violations:
- Line 9: Direct ClickHouse import (HIGH confidence)
- Line 13: Client instantiation (HIGH confidence)  
- Line 16: Raw SQL string (HIGH confidence)

## Expected Behavior

Claude should now post inline comments directly on the problematic lines of code with confidence levels and fix recommendations.

## Fallback Plan

If v1 continues to fail, we can revert to @beta version which users confirm works for PR comments.