### PR TITLE
🎯 Final Test: Inline Comments with allowedTools

### DIFF
--- a/.github/workflows/claude-code-integration.yml
+++ b/.github/workflows/claude-code-integration.yml
@@ -162,6 +162,7 @@ jobs:
           claude_args: |
             --max-turns 5
             --model claude-3-haiku-20240307
+            --max-tokens 4096
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
           prompt: |
             Review this pull request for architectural violations and post inline comments on any violations found.

--- a/claude-validation.ts
+++ b/claude-validation.ts
@@ -1,8 +1,8 @@
 /**
- * CLAUDE CODE VALIDATION - REVIEW COMMENTS FIX
+ * CLAUDE CODE VALIDATION - INLINE COMMENTS TEST
  *
- * Removed track_progress to enable actual PR review comments
- * Should post line-specific violation findings
+ * Testing with --allowedTools mcp__github_inline_comment__create_inline_comment
+ * Should now post inline comments on specific lines
  */
 
 // HIGH CONFIDENCE: Direct ClickHouse import


### PR DESCRIPTION
## The Ultimate Test for Claude Code Inline Comments

### Configuration Now on Main:
✅ **--allowedTools** with mcp__github_inline_comment__create_inline_comment
✅ **No use_sticky_comment** (was blocking inline comments)
✅ **No track_progress** (was causing todo lists)
✅ **Haiku model** for cost efficiency
✅ **Explicit prompt** to use inline comment tool

### Test File Violations:

claude-validation.ts contains 3 HIGH confidence violations:
- **Line 9**: Direct @clickhouse/client import
- **Line 13**: Direct client instantiation  
- **Line 16**: Raw SQL string

### Expected Behavior:

Claude should now post inline PR review comments directly on lines 9, 13, and 16 with:
- 🚨 HIGH Confidence markers
- Specific violation descriptions
- Fix recommendations with code examples

### Research Summary:

Based on anthropics/claude-code-action own workflows and issues:
- They use --allowedTools to enable inline comments
- Issue #60 confirms this is required
- Issue #567 shows v1 has known PR comment issues

Let's see if this finally works! 🤞