### PR TITLE
🔧 Final: Haiku with 4096 token limit for inline comments

### DIFF
--- a/.github/workflows/claude-code-integration.yml
+++ b/.github/workflows/claude-code-integration.yml
@@ -162,7 +162,7 @@ jobs:
           claude_args: |
             --max-turns 5
             --model claude-3-haiku-20240307
-            --max-tokens 4096
+            --max-output-tokens 4096
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
           prompt: |
             Review this pull request for architectural violations and post inline comments on any violations found.

--- a/claude-validation.ts
+++ b/claude-validation.ts
@@ -1,8 +1,8 @@
 /**
- * CLAUDE CODE VALIDATION - INLINE COMMENTS TEST
+ * CLAUDE CODE VALIDATION - HAIKU WITH TOKEN LIMIT
  *
- * Testing with --allowedTools mcp__github_inline_comment__create_inline_comment
- * Should now post inline comments on specific lines
+ * Using Haiku with max_tokens=4096 limit
+ * Should post inline comments without API errors
  */
 
 // HIGH CONFIDENCE: Direct ClickHouse import


### PR DESCRIPTION
## Now with Token Limit Fixed!

Haiku was failing with: max_tokens: 8192 > 4096

### Configuration:
- --model claude-3-haiku-20240307
- --max-tokens 4096 (fixed!)  
- --allowedTools mcp__github_inline_comment__create_inline_comment
- No use_sticky_comment or track_progress

### Test Violations:
- Line 9: Direct ClickHouse import
- Line 13: Client instantiation
- Line 16: Raw SQL string

Claude should now work without API errors and post inline comments.